### PR TITLE
PL-7269: Legger støtte for AfpOffentligLivsvarig i tjenestene BeregnAlderspensjon2025ForsteUttak, BeregnForsorgingstillegg, BeregnInstitusjonsopphold og RevurderingAlderspensjon2025.

### DIFF
--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregnetUtbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregnetUtbetalingsperiode.kt
@@ -38,4 +38,5 @@ class BeregnetUtbetalingsperiode : Serializable {
     var antallSerkullsbarn = 0
     var ytelseskomponenter: Map<String, Ytelseskomponent> = mutableMapOf()
 
+    var afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.beregning2011.AfpLivsvarig
+import no.nav.pensjon.regler.domain.beregning2011.AfpOffentligLivsvarigGrunnlag
 import no.nav.pensjon.regler.domain.grunnlag.DelingstallUtvalg
 import no.nav.pensjon.regler.domain.grunnlag.ForholdstallUtvalg
 import no.nav.pensjon.regler.domain.grunnlag.GarantitilleggsbeholdningGrunnlag
@@ -19,4 +20,5 @@ class BeregnAlderspensjon2025ForsteUttakRequest : ServiceRequest() {
     var epsMottarPensjon = false
     var afpLivsvarig: AfpLivsvarig? = null
     var garantitilleggsbeholdningGrunnlag: GarantitilleggsbeholdningGrunnlag? = null
+    var afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnForsorgingstilleggRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnForsorgingstilleggRequest.kt
@@ -45,6 +45,11 @@ class BeregnForsorgingstilleggRequest : ServiceRequest() {
     var beregningsResultatAfpPrivatTilstotende: BeregningsResultatAfpPrivat? = null
 
     /**
+     * AfpOffentligLivsvarigGrunnlag for tilstøtende
+     */
+    var afpOffentligLivsvarigGrunnlagTilstotende: AfpOffentligLivsvarigGrunnlag? = null
+
+    /**
      * Beregningen ved virkningstidspunkt. Vil inneholde en AldersberegningKapittel19,
      * som igjen inneholder MinstePensjonsnivå, Basispensjon, Restpensjon, PensjonUnderUtbetaling
      * og BeregningsInformasjon.

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnInstitusjonsoppholdRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnInstitusjonsoppholdRequest.kt
@@ -1,10 +1,7 @@
 package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.beregning.Beregning
-import no.nav.pensjon.regler.domain.beregning2011.AbstraktBeregningsResultat
-import no.nav.pensjon.regler.domain.beregning2011.AfpLivsvarig
-import no.nav.pensjon.regler.domain.beregning2011.BeregningsresultatUforetrygd
-import no.nav.pensjon.regler.domain.beregning2011.SisteAldersberegning2011
+import no.nav.pensjon.regler.domain.beregning2011.*
 import no.nav.pensjon.regler.domain.grunnlag.ForholdstallUtvalg
 import no.nav.pensjon.regler.domain.krav.Kravhode
 import no.nav.pensjon.regler.domain.vedtak.VilkarsVedtak
@@ -30,6 +27,7 @@ class BeregnInstitusjonsoppholdRequest : ServiceRequest() {
 
     /* Informasjon om afpPrivatberegning for bruker1. Kun påkrevd dersom bruker1 har AfpPrivat. */
     var bruker1afpLivsvarig: AfpLivsvarig? = null
+    var bruker1afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null
 
     // bruker2 beregning1967
     var bruker2Beregning: Beregning? = null
@@ -45,4 +43,5 @@ class BeregnInstitusjonsoppholdRequest : ServiceRequest() {
 
     /* Informasjon om afpPrivatberegning for bruker2. Kun påkrevd dersom bruker2 har AfpPrivat. */
     var bruker2afpLivsvarig: AfpLivsvarig? = null
+    var bruker2afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2025Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2025Request.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.beregning2011.AfpLivsvarig
+import no.nav.pensjon.regler.domain.beregning2011.AfpOffentligLivsvarigGrunnlag
 import no.nav.pensjon.regler.domain.beregning2011.SisteAldersberegning2011
 import no.nav.pensjon.regler.domain.grunnlag.DelingstallUtvalg
 import no.nav.pensjon.regler.domain.grunnlag.ForholdstallUtvalg
@@ -21,4 +22,5 @@ class RevurderingAlderspensjon2025Request : ServiceRequest() {
     var sisteAldersBeregning2011: SisteAldersberegning2011? = null
     var afpLivsvarig: AfpLivsvarig? = null
     var garantitilleggsbeholdningGrunnlag: GarantitilleggsbeholdningGrunnlag? = null
+    var afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null
 }


### PR DESCRIPTION
Legger også støtte for AfpOffentligLivsvarig i BeregnetUtbetalingsperiode slik at det kan legges på ytelseskomponenten ved mapping til pensjon-regler domene