### PR TITLE
Release/v2.0.0

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'temurin'
       - name: Run Maven release
         run: ./releaseGithub.sh

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
     - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - name: Set up JDK 21
+    - name: Set up JDK 25
       uses: actions/setup-java@v5
       with:
-        java-version: 21
+        java-version: 25
         distribution: 'temurin'
     - name: Build with Maven
       run: mvn -B clean install

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7.3.0
         with:
           commitish: master
         env:

--- a/.github/workflows/releaseOnPublish.yml
+++ b/.github/workflows/releaseOnPublish.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: JDK 21
+      - name: JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - name: Run Maven release
         run: ./releaseGithub.sh
         env:

--- a/.github/workflows/releaseOnPublish.yml
+++ b/.github/workflows/releaseOnPublish.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: JDK 21
         uses: actions/setup-java@v5
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.19.0</version>
+			<version>3.20.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.jdk.version>17</java.jdk.version>
-        <kotlin.version>2.2.20</kotlin.version>
+        <kotlin.version>2.3.10</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.4.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <kotlin.code.style>official</kotlin.code.style>
-        <jackson.version>2.17.0</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
     </properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>no.nav.pensjon.regler</groupId>
 	<artifactId>pensjon-regler-api</artifactId>
-	<version>1.4.0</version>
+	<version>2.0.0</version>
 	<packaging>jar</packaging>
 	<name>NAV :: Pensjon-Regler API</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>no.nav.pensjon.regler</groupId>
 	<artifactId>pensjon-regler-api</artifactId>
-	<version>1.7.2</version>
+	<version>2.0.0</version>
 	<packaging>jar</packaging>
 	<name>NAV :: Pensjon-Regler API</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <kotlin.code.style>official</kotlin.code.style>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.21.1</jackson.version>
     </properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,11 @@
 	<name>NAV :: Pensjon-Regler API</name>
 
     <properties>
-        <java.jdk.version>17</java.jdk.version>
+        <java.jdk.version>25</java.jdk.version>
         <kotlin.version>2.3.10</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <kotlin.code.style>official</kotlin.code.style>
         <jackson.version>2.21.1</jackson.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>${jackson.version}</version>
+			<version>2.21</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <kotlin.code.style>official</kotlin.code.style>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.21</jackson.version>
     </properties>
 
 	<dependencies>

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/Pakkseddel.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/Pakkseddel.kt
@@ -23,14 +23,6 @@ class Pakkseddel : Serializable {
         get() = merknadListe.isEmpty()
 
     /**
-     * Er 'true' dersom ingen feilmeldinger er vedlagt pakkseddelen (merknadslisten er tom).
-     */
-    @Deprecated("Ikke lenger i bruk.")
-    @get:JsonGetter
-    val annenTjenesteOk: Boolean
-        get() = merknadListe.isEmpty()
-
-    /**
      * Liste av merknader. Beskriver hvordan pensjon-regler kom frem til `kontrollTjenesteOk`.
      */
     var merknadListe: List<Merknad> = mutableListOf()

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/SatsResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/SatsResultat.kt
@@ -5,11 +5,7 @@ import java.util.*
 import java.time.LocalDate
 
 class SatsResultat : Serializable {
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
     var verdi = 0.0
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/TTPeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/TTPeriode.kt
@@ -10,15 +10,11 @@ open class TTPeriode : Serializable {
     /**
      * Fra-og-med dato for perioden.
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Til-og-med dato for perioden.
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/Trygdetid.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/Trygdetid.kt
@@ -47,8 +47,6 @@ class Trygdetid : Serializable {
     /**
      * Dato fremtidig trygdetid regnes fra.
      */
-    @Deprecated("Use ftt_fomLd instead")
-    var ftt_fom: Date? = null
     var ftt_fomLd: LocalDate? = null
 
     /**
@@ -139,15 +137,11 @@ class Trygdetid : Serializable {
     /**
      * Trygdetidens virkningsdato fom. Brukes ved fastsettelse av periodisert trygdetid for AP2011/AP2016 og AP2025
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     /**
      * Trygdetidens virkningsdato tom. Brukes ved fastsettelse av periodisert trygdetid for AP2011/AP2016 og AP2025
      */
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
     var anvendtFlyktningEnum: UtfallEnum? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/afpoppgjor/AFPEtteroppgjorgrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/afpoppgjor/AFPEtteroppgjorgrunnlag.kt
@@ -9,8 +9,6 @@ class AFPEtteroppgjorgrunnlag(
     /**
      * Personens Fødselsdato
      */
-    @Deprecated("Use fodselsdatoLd instead")
-    var fodselsdato: Date? = null,
     var fodselsdatoLd: LocalDate? = null,
 
     /**
@@ -43,15 +41,11 @@ class AFPEtteroppgjorgrunnlag(
      * Pensjonsgivende inntekt i preioden (fra SKD)
      */
     var pgi: Int = 0,
-    @Deprecated("Use uttaksdatoLd instead")
-    var uttaksdato: Date? = null,
     var uttaksdatoLd: LocalDate? = null,
 
     /**
      * Hvis pensjonen opphørte midt i oppgjørsåret skal denne settes til opphørsdato
      */
-    @Deprecated("Use opphorsdatoLd instead")
-    var opphorsdato: Date? = null,
     var opphorsdatoLd: LocalDate? = null,
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/afpoppgjor/AFPetteroppgjor.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/afpoppgjor/AFPetteroppgjor.kt
@@ -2,22 +2,17 @@ package no.nav.pensjon.regler.domain.afpoppgjor
 
 import no.nav.pensjon.regler.domain.BatchStatus
 import java.io.Serializable
-import java.util.*
 import java.time.LocalDate
 
 class AFPetteroppgjor(
     /**
      * Datoen for uttak av AFP - hvis dette skjedde i oppgjørsperioden
      */
-    @Deprecated("Use uttaksdatoLd instead")
-    var uttaksdato: Date? = null,
     var uttaksdatoLd: LocalDate? = null,
 
     /**
      * Datoen for opphår av AFP - hvis dette skjedde i oppgjørsperioden
      */
-    @Deprecated("Use opphorsdatoLd instead")
-    var opphorsdato: Date? = null,
     var opphorsdatoLd: LocalDate? = null,
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/afpoppgjor/AfpUtbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/afpoppgjor/AfpUtbetalingsperiode.kt
@@ -9,15 +9,11 @@ class AfpUtbetalingsperiode : Serializable {
     /**
      * Periodens fradato - not null
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     /**
      * Periodens tildato
      */
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Beregning.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/Beregning.kt
@@ -33,15 +33,11 @@ class Beregning : Serializable {
     /**
      * Virkningstidspunktet ytelsen kan utbetales fra.
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     /**
      * Virkningstidspunktet ytelsen kan utbetales til.
      */
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
 
     /**
@@ -369,8 +365,6 @@ class Beregning : Serializable {
      * Anvendt uføretidspunkt. Hentes normalt fra Uføregrunnlag men kan være hentet fra Uførehistorikk ved
      * lønnsomhetsberegning.
      */
-    @Deprecated("Use uftLd instead")
-    var uft: Date? = null
     var uftLd: LocalDate? = null
 
     /**
@@ -378,8 +372,6 @@ class Beregning : Serializable {
      * Anvendt yrkesskadetidspunkt. Hentes normalt fra yrkesskadegrunnlag men kan være hentet fra yrkesskadehistorikk
      * ved lønnsomhetsberegning.
      */
-    @Deprecated("Use ystLd instead")
-    var yst: Date? = null
     var ystLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/BeregningUforeperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning/BeregningUforeperiode.kt
@@ -18,8 +18,6 @@ class BeregningUforeperiode : Serializable {
      * Dato for uføretidspunktet.
      */
     @JvmField
-    @Deprecated("Use uftLd instead")
-    var uft: Date? = null
     var uftLd: LocalDate? = null
 
     /**
@@ -67,32 +65,24 @@ class BeregningUforeperiode : Serializable {
      * Dato for virkningsåret for denne Uføreperioden.
      */
     @JvmField
-    @Deprecated("Use virkLd instead")
-    var virk: Date? = null
     var virkLd: LocalDate? = null
 
     /**
      * Dato for når Uføreperioden avsluttes.
      */
     @JvmField
-    @Deprecated("Use uftTomLd instead")
-    var uftTom: Date? = null
     var uftTomLd: LocalDate? = null
 
     /**
      * Dato for når Uføregraden starter.
      */
     @JvmField
-    @Deprecated("Use ufgFomLd instead")
-    var ufgFom: Date? = null
     var ufgFomLd: LocalDate? = null
 
     /**
      * Dato for når Uføregraden avsluttes.
      */
     @JvmField
-    @Deprecated("Use ufgTomLd instead")
-    var ufgTom: Date? = null
     var ufgTomLd: LocalDate? = null
 
     /**
@@ -229,8 +219,6 @@ class BeregningUforeperiode : Serializable {
      * Det uføretidspunkt som er angitt for perioden, men ikke nødvendigvis anvendt.
      * **/
     @JvmField
-    @Deprecated("Use angittUforetidspunktLd instead")
-    var angittUforetidspunkt: Date? = null
     var angittUforetidspunktLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBarnetilleggperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBarnetilleggperiode.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import no.nav.pensjon.regler.domain.trygdetid.Brok
 import java.io.Serializable
-import java.util.*
 import java.time.LocalDate
 
 @JsonSubTypes(
@@ -17,15 +16,11 @@ abstract class AbstraktBarnetilleggperiode : Serializable {
     /**
      * Start for periode med et antall barn.
      */
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
 
     /**
      * Stopp for periode med et antall barn.
      */
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBeregningsResultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/AbstraktBeregningsResultat.kt
@@ -7,7 +7,6 @@ import no.nav.pensjon.regler.domain.enum.Beregningsarsak
 import no.nav.pensjon.regler.domain.enum.BorMedTypeEnum
 import no.nav.pensjon.regler.domain.enum.SivilstandEnum
 import java.io.Serializable
-import java.util.*
 import java.time.LocalDate
 
 @JsonSubTypes(
@@ -19,8 +18,6 @@ import java.time.LocalDate
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 abstract class AbstraktBeregningsResultat protected constructor() : Serializable {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var pensjonUnderUtbetaling: PensjonUnderUtbetaling? = null
     var uttaksgrad = 0

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregnetUtbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregnetUtbetalingsperiode.kt
@@ -9,15 +9,11 @@ class BeregnetUtbetalingsperiode() : Serializable {
     /**
      * Periodens startdato.
      */
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
 
     /**
      * Periodens sluttdato.
      */
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregningsInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregningsInformasjon.kt
@@ -11,12 +11,8 @@ import java.io.Serializable
 
 class BeregningsInformasjon : Serializable {
     var forholdstallUttak = 0.0
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("forholdstallVedNormertPensjonsalder"))
-    var forholdstall67 = 0.0
     var forholdstallVedNormertPensjonsalder = 0.0
     var delingstallUttak = 0.0
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("delingstallVedNormertPensjonsalder"))
-    var delingstall67 = 0.0
     var delingstallVedNormertPensjonsalder = 0.0
     var spt: Sluttpoengtall? = null
     var opt: Sluttpoengtall? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregningsvilkarPeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/BeregningsvilkarPeriode.kt
@@ -14,15 +14,11 @@ class BeregningsvilkarPeriode : Serializable {
      * Fom dato for perioden de angitte beregningsvilkår og vilkår gjelder for
      */
     @JvmField
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
     /**
      * Tom dato for perioden de angitte beregningsvilkår og vilkår gjelder for
      */
     @JvmField
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/FremskrivingsDetaljer.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/FremskrivingsDetaljer.kt
@@ -1,12 +1,9 @@
 package no.nav.pensjon.regler.domain.beregning2011
 
 import java.io.Serializable
-import java.util.*
 import java.time.LocalDate
 
 class FremskrivingsDetaljer : Serializable, IFremskriving {
-    @Deprecated("Use justeringTomDatoLd instead")
-    // override var justeringTomDato: Date? = null
     override var justeringTomDatoLd: LocalDate? = null
     override var justeringsfaktor = 0.0
     override var teller = 0.0
@@ -15,9 +12,6 @@ class FremskrivingsDetaljer : Serializable, IFremskriving {
 
     constructor()
     constructor(frem: FremskrivingsDetaljer) : this() {
-//        if (frem.justeringTomDato != null) {
-//            justeringTomDato = frem.justeringTomDato!!.clone() as Date
-//        }
         if(frem.justeringTomDatoLd != null) {
             justeringTomDatoLd = frem.justeringTomDatoLd
         }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/FremskrivingsDetaljer.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/FremskrivingsDetaljer.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 class FremskrivingsDetaljer : Serializable, IFremskriving {
     @Deprecated("Use justeringTomDatoLd instead")
-    override var justeringTomDato: Date? = null
+    // override var justeringTomDato: Date? = null
     override var justeringTomDatoLd: LocalDate? = null
     override var justeringsfaktor = 0.0
     override var teller = 0.0
@@ -15,9 +15,9 @@ class FremskrivingsDetaljer : Serializable, IFremskriving {
 
     constructor()
     constructor(frem: FremskrivingsDetaljer) : this() {
-        if (frem.justeringTomDato != null) {
-            justeringTomDato = frem.justeringTomDato!!.clone() as Date
-        }
+//        if (frem.justeringTomDato != null) {
+//            justeringTomDato = frem.justeringTomDato!!.clone() as Date
+//        }
         if(frem.justeringTomDatoLd != null) {
             justeringTomDatoLd = frem.justeringTomDatoLd
         }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/GjenlevendetilleggInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/GjenlevendetilleggInformasjon.kt
@@ -20,15 +20,11 @@ class GjenlevendetilleggInformasjon : Serializable {
     /**
      * dødsdato.
      */
-    @Deprecated("Use dodstidspunktLd instead")
-    var dodstidspunkt: Date? = null
     var dodstidspunktLd: LocalDate? = null
 
     /**
      * Hvis ufør ved død er dette gjeldende uføretidspunkt.
      */
-    @Deprecated("Use uforetidspunktLd instead")
-    var uforetidspunkt: Date? = null
     var uforetidspunktLd: LocalDate? = null
 
     /**
@@ -69,8 +65,6 @@ class GjenlevendetilleggInformasjon : Serializable {
     /**
      * Skadetidspunkt ved yrkesskade.
      */
-    @Deprecated("Use skadetidspunktLd instead")
-    var skadetidspunkt: Date? = null
     var skadetidspunktLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/IJustering.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/IJustering.kt
@@ -12,7 +12,5 @@ import java.time.LocalDate
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 interface IJustering {
     var justeringsfaktor: Double
-    @Deprecated("Use justeringTomDatoLd instead")
-    var justeringTomDato: Date?
     var justeringTomDatoLd: LocalDate?
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/LonnsvekstDetaljer.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/LonnsvekstDetaljer.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 
 class LonnsvekstDetaljer : Serializable, ILonnsvekst {
     @Deprecated("Use justeringTomDatoLd instead")
-    override var justeringTomDato: Date? = null
+    // override var justeringTomDato: Date? = null
     override var justeringTomDatoLd: LocalDate? = null
     override var justeringsfaktor = 0.0
     override var lonnsvekst = 0.0
@@ -14,9 +14,9 @@ class LonnsvekstDetaljer : Serializable, ILonnsvekst {
     constructor()
 
     constructor(lvd: LonnsvekstDetaljer) : this() {
-        if (lvd.justeringTomDato != null) {
-            justeringTomDato = lvd.justeringTomDato!!.clone() as Date
-        }
+//        if (lvd.justeringTomDato != null) {
+//            justeringTomDato = lvd.justeringTomDato!!.clone() as Date
+//        }
         if(lvd.justeringTomDatoLd != null) {
             justeringTomDatoLd = lvd.justeringTomDatoLd
         }
@@ -25,10 +25,10 @@ class LonnsvekstDetaljer : Serializable, ILonnsvekst {
     }
 
     constructor(
-        justeringTomDato: Date? = null,
+        // justeringTomDato: Date? = null,
         justeringsfaktor: Double = 0.0,
         lonnsvekst: Double = 0.0) {
-        this.justeringTomDato = justeringTomDato
+//        this.justeringTomDato = justeringTomDato
         this.justeringsfaktor = justeringsfaktor
         this.lonnsvekst = lonnsvekst
     }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/LonnsvekstDetaljer.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/LonnsvekstDetaljer.kt
@@ -1,12 +1,9 @@
 package no.nav.pensjon.regler.domain.beregning2011
 
 import java.io.Serializable
-import java.util.*
 import java.time.LocalDate
 
 class LonnsvekstDetaljer : Serializable, ILonnsvekst {
-    @Deprecated("Use justeringTomDatoLd instead")
-    // override var justeringTomDato: Date? = null
     override var justeringTomDatoLd: LocalDate? = null
     override var justeringsfaktor = 0.0
     override var lonnsvekst = 0.0
@@ -14,9 +11,6 @@ class LonnsvekstDetaljer : Serializable, ILonnsvekst {
     constructor()
 
     constructor(lvd: LonnsvekstDetaljer) : this() {
-//        if (lvd.justeringTomDato != null) {
-//            justeringTomDato = lvd.justeringTomDato!!.clone() as Date
-//        }
         if(lvd.justeringTomDatoLd != null) {
             justeringTomDatoLd = lvd.justeringTomDatoLd
         }
@@ -25,10 +19,8 @@ class LonnsvekstDetaljer : Serializable, ILonnsvekst {
     }
 
     constructor(
-        // justeringTomDato: Date? = null,
         justeringsfaktor: Double = 0.0,
         lonnsvekst: Double = 0.0) {
-//        this.justeringTomDato = justeringTomDato
         this.justeringsfaktor = justeringsfaktor
         this.lonnsvekst = lonnsvekst
     }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/LonnsvekstInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/LonnsvekstInformasjon.kt
@@ -13,8 +13,6 @@ class LonnsvekstInformasjon : Serializable {
     /**
      * @param reguleringsDato the reguleringsDato to set
      */
-    @Deprecated("Use reguleringsDatoLd instead")
-    var reguleringsDato: Date? = null
     var reguleringsDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Pensjonstillegg.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Pensjonstillegg.kt
@@ -12,8 +12,6 @@ import no.nav.pensjon.regler.domain.enum.YtelseskomponentTypeEnum
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 open class Pensjonstillegg : Ytelseskomponent {
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("forholdstallVedNormertPensjonsalder"))
-    var forholdstall67 = 0.0
     var forholdstallVedNormertPensjonsalder = 0.0
     var minstepensjonsnivaSats = 0.0
     var minstepensjonsnivaSatsTypeEnum: MinstePensjonsnivaSatsEnum? = null
@@ -26,7 +24,6 @@ open class Pensjonstillegg : Ytelseskomponent {
     }
 
     constructor(pt: Pensjonstillegg) : super(pt) {
-        forholdstall67 = pt.forholdstall67
         forholdstallVedNormertPensjonsalder = pt.forholdstallVedNormertPensjonsalder
         minstepensjonsnivaSats = pt.minstepensjonsnivaSats
         if (pt.minstepensjonsnivaSatsTypeEnum != null) {

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Regelendring.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Regelendring.kt
@@ -9,8 +9,6 @@ class Regelendring : Serializable {
     /**
      * Datoen en regel- eller satsendring har virkningsdato.
      */
-    @Deprecated("Use endringsdatoLd instead")
-    var endringsdato: Date? = null
     var endringsdatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/SisteBeregning.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/SisteBeregning.kt
@@ -19,8 +19,6 @@ import java.time.LocalDate
 )
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 abstract class SisteBeregning protected constructor() : Serializable {
-    @Deprecated("Use virkDatoLd instead")
-    var virkDato: Date? = null
     var virkDatoLd: LocalDate? = null
     var tt_anv = 0
     var resultatTypeEnum: ResultattypeEnum? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Uforetrygdberegning.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/beregning2011/Uforetrygdberegning.kt
@@ -14,14 +14,10 @@ class Uforetrygdberegning : Beregning2011() {
     var minsteytelse: Minsteytelse? = null
     var prorataBrok: Brok? = null
     var uforegrad = 0
-    @Deprecated("Use uforetidspunktLd instead")
-    var uforetidspunkt: Date? = null
     var uforetidspunktLd: LocalDate? = null
     var egenopptjentUforetrygd: EgenopptjentUforetrygd? = null
     var egenopptjentUforetrygdBest = false
     var yrkesskadegrad = 0
-    @Deprecated("Use yrkesskadetidspunktLd instead")
-    var yrkesskadetidspunkt: Date? = null
     var yrkesskadetidspunktLd: LocalDate? = null
     var mottarMinsteytelse = false
 

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/AfpHistorikk.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/AfpHistorikk.kt
@@ -10,11 +10,7 @@ class AfpHistorikk : Serializable {
      * Fremtidig pensjonspoeng
      */
     var afpFpp = 0.0
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
     var afpPensjonsgrad = 0
     var afpOrdningEnum: AFPtypeEnum? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/AfpTpoUpGrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/AfpTpoUpGrunnlag.kt
@@ -13,8 +13,6 @@ class AfpTpoUpGrunnlag : Serializable {
     /**
      * Dato som beløpet ovenfor var gyldig
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/ArbeidsforholdEtterUforgrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/ArbeidsforholdEtterUforgrunnlag.kt
@@ -8,8 +8,6 @@ class ArbeidsforholdEtterUforgrunnlag : Serializable {
     /**
      * Fom date for arbeidsforholdet.
      */
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Arbeidsforholdsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Arbeidsforholdsgrunnlag.kt
@@ -8,15 +8,11 @@ class Arbeidsforholdsgrunnlag : Serializable {
     /**
      * Fom dato for arbeidsforholdet.
      */
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
 
     /**
      * Tom dato for arbeidsforholdet.
      */
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/BarnDetalj.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/BarnDetalj.kt
@@ -20,15 +20,11 @@ class BarnDetalj : Serializable {
     /**
      * Fra-og-med dato for når barnet bor sammen med begge foreldrene.
      */
-    @Deprecated("Use borFomDatoLd instead")
-    var borFomDato: Date? = null
     var borFomDatoLd: LocalDate? = null
 
     /**
      * Til-og-med dato for når barnet bor sammen med begge foreldrene.
      */
-    @Deprecated("Use borTomDatoLd instead")
-    var borTomDato: Date? = null
     var borTomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/BarnetilleggVurderingsperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/BarnetilleggVurderingsperiode.kt
@@ -5,11 +5,7 @@ import java.util.*
 import java.time.LocalDate
 
 class BarnetilleggVurderingsperiode : Serializable {
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
     var btVilkarListe: List<BarnetilleggVilkar> = mutableListOf()
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/ForsteVirkningsdatoGrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/ForsteVirkningsdatoGrunnlag.kt
@@ -7,11 +7,7 @@ import java.util.*
 import java.time.LocalDate
 
 class ForsteVirkningsdatoGrunnlag : Serializable {
-    @Deprecated("Use virkningsdatoLd instead")
-    var virkningsdato: Date? = null
     var virkningsdatoLd: LocalDate? = null
-    @Deprecated("Use kravFremsattDatoLd instead")
-    var kravFremsattDato: Date? = null
     var kravFremsattDatoLd: LocalDate? = null
     var bruker: PenPerson? = null
     var annenPerson: PenPerson? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/ForstegangstjenestePeriode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/ForstegangstjenestePeriode.kt
@@ -6,11 +6,7 @@ import java.util.*
 import java.time.LocalDate
 
 class ForstegangstjenestePeriode : Serializable {
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
     var periodeTypeEnum: ForstegangstjenestetypeEnum? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/GarantiTrygdetid.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/GarantiTrygdetid.kt
@@ -6,11 +6,7 @@ import java.time.LocalDate
 
 class GarantiTrygdetid : Serializable {
     var trygdetid_garanti = 0
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Garantipensjonsbeholdning.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Garantipensjonsbeholdning.kt
@@ -7,8 +7,6 @@ import no.nav.pensjon.regler.domain.enum.GarantiPensjonsnivaSatsEnum
 class Garantipensjonsbeholdning() : Beholdning() {
     var justertGarantipensjonsniva: JustertGarantipensjonsniva? = null
     var pensjonsbeholdning = 0.0
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("delingstallVedNormertPensjonsalder"))
-    var delingstall67 = 0.0
     var delingstallVedNormertPensjonsalder = 0.0
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/InntektKontrollGrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/InntektKontrollGrunnlag.kt
@@ -31,8 +31,6 @@ class InntektKontrollGrunnlag : Serializable {
     var beregnetUtbetalingsperiodeEPSListe: List<BeregnetUtbetalingsperiode> = mutableListOf()
 
     /** Angir hvilken måned som kontrolleres.  */
-    @Deprecated("Use kontrolldatoLd instead")
-    var kontrolldato: Date? = null
     var kontrolldatoLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Inntektsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Inntektsgrunnlag.kt
@@ -41,15 +41,11 @@ class Inntektsgrunnlag() : Serializable {
     /**
      * fra-og-med dato for gyldigheten av inntektsgrunnlaget.
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * til-og-med dato for gyldigheten av inntektsgrunnlaget.
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/InstOpphFasteUtgifterperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/InstOpphFasteUtgifterperiode.kt
@@ -21,15 +21,11 @@ class InstOpphFasteUtgifterperiode : Serializable {
     /**
      * Dato bruker ble innlagt
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Dato bruker ble skrevet ut
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/InstOpphReduksjonsperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/InstOpphReduksjonsperiode.kt
@@ -17,15 +17,11 @@ class InstOpphReduksjonsperiode : Serializable {
     /**
      * Fra og med dato
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Til og med dato
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/PersonDetalj.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/PersonDetalj.kt
@@ -23,15 +23,11 @@ open class PersonDetalj : Serializable {
     /**
      * Fra-og-med dato for rollens gyldighet.
      */
-    @Deprecated("Use rolleFomDatoLd instead")
-    var rolleFomDato: Date? = null
     var rolleFomDatoLd: LocalDate? = null
 
     /**
      * Til-og-med dato for rollens gyldighet.
      */
-    @Deprecated("Use rolleTomDatoLd instead")
-    var rolleTomDato: Date? = null
     var rolleTomDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/PersonOpptjeningsgrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/PersonOpptjeningsgrunnlag.kt
@@ -19,7 +19,5 @@ class PersonOpptjeningsgrunnlag : Serializable {
     /**
      * Brukers Fødselsdato
      */
-    @Deprecated("Use fodselsdatoLd instead")
-    var fodselsdato: Date? = null
     var fodselsdatoLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Persongrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Persongrunnlag.kt
@@ -26,16 +26,12 @@ class Persongrunnlag() : Serializable {
      * søkers Fødselsdato,brukes kun ved simuleringer.Da benyttes ikke reelle
      * personer.
      */
-    @Deprecated("Use fodselsdatoLd instead")
-    var fodselsdato: Date? = null
     var fodselsdatoLd: LocalDate? = null
 
     /**
      * Personens eventuelle dødsdato, brukes ved beregning av ytelser til
      * gjenlevende ektefelle og barn.
      */
-    @Deprecated("Use dodsdatoLd instead")
-    var dodsdato: Date? = null
     var dodsdatoLd: LocalDate? = null
 
     /**
@@ -63,8 +59,6 @@ class Persongrunnlag() : Serializable {
     /**
      * Dato for sist innmeldt i Folketrygden- for fremtidig trygdetid.
      */
-    @Deprecated("Use sistMedlITrygdenLd instead")
-    var sistMedlITrygden: Date? = null
     var sistMedlITrygdenLd: LocalDate? = null
 
     /**
@@ -320,8 +314,6 @@ class Persongrunnlag() : Serializable {
      * Støttefelt for virk_ikke_ufor-hacket. Feltet er ikke forventet populert.
      */
     @JsonIgnore
-    @Deprecated("Use forsteVirkLd instead")
-    var forsteVirk: Date? = null
     var forsteVirkLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/PoengarManuell.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/PoengarManuell.kt
@@ -12,15 +12,11 @@ class PoengarManuell : Serializable {
     /**
      * Poengåret fra og med dato.
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Poengåret til og med dato.
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/RegulerBeregningGrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/RegulerBeregningGrunnlag.kt
@@ -9,8 +9,6 @@ import java.time.LocalDate
 
 class RegulerBeregningGrunnlag : Serializable {
     var beregning1967: Beregning? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var uttaksgradListe: List<Uttaksgrad> = mutableListOf()
     var brukersVilkarsvedtakListe: List<VilkarsVedtak> = mutableListOf()

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Sivilstand.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Sivilstand.kt
@@ -16,15 +16,11 @@ class Sivilstand : Serializable {
     /**
      * Sivilstandens gyldighet fra-og-med dato.
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Sivilstandens gyldighet til-og-med dato
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Trygdeavtale.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Trygdeavtale.kt
@@ -39,7 +39,5 @@ class Trygdeavtale : Serializable {
     /**
      * Dato for kravdato i avtale
      */
-    @Deprecated("Use kravDatoIAvtalelandLd instead")
-    var kravDatoIAvtaleland: Date? = null
     var kravDatoIAvtalelandLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uforegrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uforegrunnlag.kt
@@ -14,15 +14,11 @@ class Uforegrunnlag : Serializable {
     /**
      * Dato for uføretidspunktet.
      */
-    @Deprecated("Use uftLd instead")
-    var uft: Date? = null
     var uftLd: LocalDate? = null
 
     /**
      * Virkningstidspunkt for hendelsen Uforegrunnlaget representerer.
      */
-    @Deprecated("Use uftVirkLd instead")
-    var uftVirk: Date? = null
     var uftVirkLd: LocalDate? = null
 
     /**
@@ -45,8 +41,6 @@ class Uforegrunnlag : Serializable {
     /**
      * Dato for rett til friinntekt.
      */
-    @Deprecated("Use friinntektsDatoLd instead")
-    var friinntektsDato: Date? = null
     var friinntektsDatoLd: LocalDate? = null
 
     /**
@@ -101,8 +95,6 @@ class Uforegrunnlag : Serializable {
     /*
        * Alternativt uføretidspunkt ung ufør ved krav før 36 år.
        */
-    @Deprecated("Use altUftUngUforLd instead")
-    var altUftUngUfor: Date? = null
     var altUftUngUforLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uforehistorikk.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uforehistorikk.kt
@@ -24,8 +24,6 @@ class Uforehistorikk() : Serializable {
      * Dato for sist innmeldt i Folketrygden- for fremtidig trygdetid.
      * Lagt inn ifm PENPORT-2222
      */
-    @Deprecated("Use sistMedlITrygdenLd instead")
-    var sistMedlITrygden: Date? = null
     var sistMedlITrygdenLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uforeperiode.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uforeperiode.kt
@@ -16,8 +16,6 @@ class Uforeperiode : Serializable {
     /**
      * Dato for uføretidspunktet.
      */
-    @Deprecated("Use uftLd instead")
-    var uft: Date? = null
     var uftLd: LocalDate? = null
 
     /**
@@ -58,29 +56,21 @@ class Uforeperiode : Serializable {
     /**
      * Dato for virkningsåret for denne Uføreperioden.
      */
-    @Deprecated("Use virkLd instead")
-    var virk: Date? = null
     var virkLd: LocalDate? = null
 
     /**
      * Dato for når Uføreperioden avsluttes.
      */
-    @Deprecated("Use uftTomLd instead")
-    var uftTom: Date? = null
     var uftTomLd: LocalDate? = null
 
     /**
      * Dato for når Uføregraden starter.
      */
-    @Deprecated("Use ufgFomLd instead")
-    var ufgFom: Date? = null
     var ufgFomLd: LocalDate? = null
 
     /**
      * Dato for når Uføregraden avsluttes.
      */
-    @Deprecated("Use ufgTomLd instead")
-    var ufgTom: Date? = null
     var ufgTomLd: LocalDate? = null
 
     /**
@@ -201,8 +191,6 @@ class Uforeperiode : Serializable {
     /*
           * Det uføretidspunkt som er angitt for perioden, men ikke nødvendigvis anvendt.
           */
-    @Deprecated("Use angittUforetidspunktLd instead")
-    var angittUforetidspunkt: Date? = null
     var angittUforetidspunktLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/UforetrygdEtteroppgjor.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/UforetrygdEtteroppgjor.kt
@@ -13,29 +13,21 @@ class UforetrygdEtteroppgjor : Serializable {
     /**
      * Angir start av arbeidsforsøk.
      */
-    @Deprecated("Use arbeidsforsokFomLd instead")
-    var arbeidsforsokFom: Date? = null
     var arbeidsforsokFomLd: LocalDate? = null
 
     /**
      * Angir slutt av arbeidsforsøk.
      */
-    @Deprecated("Use arbeidsforsokTomLd instead")
-    var arbeidsforsokTom: Date? = null
     var arbeidsforsokTomLd: LocalDate? = null
     var detaljer: List<UforetrygdEtteroppgjorDetalj> = mutableListOf()
 
     /**
      * Angir start av uføretrygd i etteroppgjørsåret.
      */
-    @Deprecated("Use periodeFomLd instead")
-    var periodeFom: Date? = null
     var periodeFomLd: LocalDate? = null
 
     /**
      * Angir slutt av uføretrygd i etteroppgjørsåret.
      */
-    @Deprecated("Use periodeTomLd instead")
-    var periodeTom: Date? = null
     var periodeTomLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/UforetrygdEtteroppgjorDetalj.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/UforetrygdEtteroppgjorDetalj.kt
@@ -9,8 +9,6 @@ class UforetrygdEtteroppgjorDetalj : Serializable {
     /**
      * Angir gyldighetsperioden for detaljen. Avgrenset av Uføreperioden og året som etteroppgjørsgrunnlaget gjelder for.
      */
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
 
     /**
@@ -31,8 +29,6 @@ class UforetrygdEtteroppgjorDetalj : Serializable {
     /**
      * Angir gyldighetsperioden for detaljen. Avgrenset av Uføreperioden og året som etteroppgjørsgrunnlaget gjelder for.
      */
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Utenlandsopphold.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Utenlandsopphold.kt
@@ -9,15 +9,11 @@ class Utenlandsopphold : Serializable {
     /**
      * Fra og med dato
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Til og med dato
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uttaksgrad.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Uttaksgrad.kt
@@ -6,21 +6,13 @@ import java.util.*
 
 // TODO Skriv om compare-funksjonen
 class Uttaksgrad : Serializable, Comparable<Uttaksgrad> {
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
 
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
     var uttaksgrad = 0
 
     override fun compareTo(other: Uttaksgrad): Int {
-        return if (fomDatoLd != null) {
-            DateCompareUtil.compareTo(fomDatoLd, other.fomDatoLd)
-        } else {
-            DateCompareUtil.compareTo(fomDato, other.fomDato)
-        }
+        return DateCompareUtil.compareTo(fomDatoLd, other.fomDatoLd)
     }
 }
 
@@ -36,21 +28,6 @@ object DateCompareUtil {
      * @param second - dato fra argument til compareTo
      * @return
      */
-
-    @Deprecated("Use compareTo(LocalDate?, LocalDate?) instead")
-    fun compareTo(first: Date?, second: Date?): Int {
-        // null sorteres foran
-        if (first == null) {
-            return if (second == null) {
-                EQUAL
-            } else {
-                BEFORE
-            }
-        } else if (second == null) {
-            return AFTER
-        }
-        return first.compareTo(second)
-    }
 
     fun compareTo(first: LocalDate?, second: LocalDate?): Int {
         // null sorteres foran

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Yrkesskadegrunnlag.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/grunnlag/Yrkesskadegrunnlag.kt
@@ -15,8 +15,6 @@ class Yrkesskadegrunnlag : Serializable {
     /**
      * Dato for skadetidspunkt.
      */
-    @Deprecated("Use ystLd instead")
-    var yst: Date? = null
     var ystLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/simulering/Simulering.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/simulering/Simulering.kt
@@ -26,8 +26,6 @@ class Simulering : Serializable {
     /**
      * Dato for når bruker ønsker å simulere uttak av pensjon fra.
      */
-    @Deprecated("Use uttaksdatoLd instead")
-    var uttaksdato: Date? = null
     var uttaksdatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/simulering/Simuleringsresultat.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/simulering/Simuleringsresultat.kt
@@ -24,8 +24,6 @@ class Simuleringsresultat : Serializable {
     /**
      * Virkningstidspunkt
      */
-    @Deprecated("Use virkLd instead")
-    var virk: Date? = null
     var virkLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/InntektEtterUforhet.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/InntektEtterUforhet.kt
@@ -15,8 +15,6 @@ class InntektEtterUforhet : AbstraktBeregningsvilkar() {
     /**
      * Virkningstidspunktet for inntekt etter uførhet.
      */
-    @Deprecated("Use ieuDatoLd instead")
-    var ieuDato: Date? = null
     var ieuDatoLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/InntektForUforhet.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/InntektForUforhet.kt
@@ -28,8 +28,6 @@ class InntektForUforhet : AbstraktBeregningsvilkar() {
     /**
      * Dato for den kroneverdi inntekt er oppgitt i.
      */
-    @Deprecated("Use ifuDatoLd instead")
-    var ifuDato: Date? = null
     var ifuDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/Skadetidspunkt.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/Skadetidspunkt.kt
@@ -4,8 +4,6 @@ import java.util.*
 import java.time.LocalDate
 
 class Skadetidspunkt : AbstraktBeregningsvilkar() {
-    @Deprecated("Use datoLd instead")
-    var dato: Date? = null
     var datoLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/Uforetidspunkt.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/Uforetidspunkt.kt
@@ -8,15 +8,11 @@ class Uforetidspunkt : AbstraktBeregningsvilkar() {
      * Angir det tidligste året som kan påvirke opptjeningen for dette uføretidspunktet.
      */
     var tidligstVurderteAr = 0
-    @Deprecated("Use uforetidspunktLd instead")
-    var uforetidspunkt: Date? = null
     var uforetidspunktLd: LocalDate? = null
 
     /**
      * Dato for når man var sist innmeldt i folketrygden. Benyttes for fremtidig trygdetid.
      */
-    @Deprecated("Use sistMedlTrygdenLd instead")
-    var sistMedlTrygden: Date? = null
     var sistMedlTrygdenLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsVedtak.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsVedtak.kt
@@ -65,12 +65,6 @@ class VilkarsVedtak : Serializable {
     var kravlinjeForsteVirkLd: LocalDate? = null
 
     /**
-     * Kravlinje som er vilkårsprøvd.
-     */
-    @Deprecated("Redundant, finnes som penPerson, kravlinjeTypeEnum og for hovedkrav, se kravlinjeListe i kravhode")
-    var kravlinje: Kravlinje? = null
-
-    /**
      * Id for personen
      */
     var penPerson: PenPerson? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsVedtak.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsVedtak.kt
@@ -42,8 +42,6 @@ class VilkarsVedtak : Serializable {
     /**
      * Dato vilkårsvedtaket har virkning fra.
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     /**
@@ -52,24 +50,18 @@ class VilkarsVedtak : Serializable {
      * vil pensjon-regler sjekke at virken på ytelsen det beregnes for er nnnnenfor
      * virkFom-virkTom. Er den utenfor blir vedtaket behandlet som ikke gyldig.
      */
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
 
     /**
      * Dato Første innvilgede vilkårsvedtak personen har fått fra trygden.
      * Eks: har personen tidligere hatt UP og før nå AP vil det være datoen for Første UP-vedtaket.
      */
-    @Deprecated("Use forsteVirkLd instead")
-    var forsteVirk: Date? = null
     var forsteVirkLd: LocalDate? = null
 
     /**
      * Dato dette vilkårsvedtakets kravlinje fårst ble innvilget.
      * Eks: personen fikk innvilget gjenlevenderett fom dette virkningstidspunkt.
      */
-    @Deprecated("Use kravlinjeForsteVirkLd instead")
-    var kravlinjeForsteVirk: Date? = null
     var kravlinjeForsteVirkLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsprovInformasjon.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsprovInformasjon.kt
@@ -17,17 +17,11 @@ import java.io.Serializable
 abstract class VilkarsprovInformasjon : Serializable {
     var ektefelleInntektOver2g = false
     var flyktning = false
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("fullPensjonVedNormertPensjonsalder"))
-    var fullPensjonVed67: FremskrevetPensjonUnderUtbetaling? = null
     var fullPensjonVedNormertPensjonsalder: FremskrevetPensjonUnderUtbetaling? = null
     var pensjonVedUttak: PensjonUnderUtbetaling? = null
     var fremskrevetAfpLivsvarig: FremskrevetAfpLivsvarig? = null
     var afpPrivatLivsvarigVedUttak: AfpPrivatLivsvarig? = null
     var afpLivsvarigBrukt = false
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("fremskrevetPensjonVedNormertPensjonsAlder"))
-    var fremskrevetPensjonVed67 = 0.0
     var fremskrevetPensjonVedNormertPensjonsAlder = 0.0
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("samletPensjonVedNormertPensjonsAlder"))
-    var samletPensjonVed67PerAr = 0.0
     var samletPensjonVedNormertPensjonsAlder = 0.0
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsprovInformasjon2025.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/domain/vedtak/VilkarsprovInformasjon2025.kt
@@ -4,13 +4,7 @@ import no.nav.pensjon.regler.domain.beregning2011.JustertGarantipensjonsniva
 import no.nav.pensjon.regler.domain.grunnlag.Beholdninger
 
 class VilkarsprovInformasjon2025 : VilkarsprovInformasjon() {
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("garPNvedNormertPensjonsalder"))
-    var garPN67: JustertGarantipensjonsniva? = null
     var garPNvedNormertPensjonsalder: JustertGarantipensjonsniva? = null
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("garPNvedNormertPensjonsalderProRata"))
-    var garPN67ProRata: JustertGarantipensjonsniva? = null
     var garPNvedNormertPensjonsalderProRata: JustertGarantipensjonsniva? = null
-    @Deprecated("Avvikles.", replaceWith = ReplaceWith("beholdningerVed67vedNormertPensjonsalder"))
-    var beholdningerVed67: Beholdninger? = null
     var beholdningerVedNormertPensjonsalder: Beholdninger? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAfpPrivatRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAfpPrivatRequest.kt
@@ -9,14 +9,10 @@ import java.time.LocalDate
 class BeregnAfpPrivatRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: ArrayList<VilkarsVedtak> = ArrayList()
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var justeringsbelop = 0
     var referansebelop = 0
     var ftKompensasjonstillegg = 0.0
     var sisteAfpPrivatBeregning: BeregningsResultatAfpPrivat? = null
-    @Deprecated("Use virkFomAfpPrivatUttakLd instead")
-    var virkFomAfpPrivatUttak: Date? = null
     var virkFomAfpPrivatUttakLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2011ForsteUttakRequest.kt
@@ -11,11 +11,7 @@ class BeregnAlderspensjon2011ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
     var ektefellenMottarPensjon = false
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2016ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2016ForsteUttakRequest.kt
@@ -11,8 +11,6 @@ class BeregnAlderspensjon2016ForsteUttakRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var epsMottarPensjon = false
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
@@ -9,8 +9,6 @@ import java.util.*
 import java.time.LocalDate
 
 class BeregnAlderspensjon2025ForsteUttakRequest : ServiceRequest() {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnAlderspensjon2025ForsteUttakRequest.kt
@@ -2,18 +2,15 @@ package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.beregning2011.AfpOffentligLivsvarigGrunnlag
 import no.nav.pensjon.regler.domain.beregning2011.AfpPrivatLivsvarig
-import no.nav.pensjon.regler.domain.grunnlag.InfoPavirkendeYtelse
 import no.nav.pensjon.regler.domain.krav.Kravhode
 import no.nav.pensjon.regler.domain.vedtak.VilkarsVedtak
-import java.util.*
 import java.time.LocalDate
+import java.util.*
 
 class BeregnAlderspensjon2025ForsteUttakRequest : ServiceRequest() {
     var virkFomLd: LocalDate? = null
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
-    @Deprecated("Felt er ikke i bruk.")
-    var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
     var epsMottarPensjon = false
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
     var afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnForsorgingstilleggRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnForsorgingstilleggRequest.kt
@@ -45,12 +45,6 @@ class BeregnForsorgingstilleggRequest : ServiceRequest() {
     var beregningsResultatAfpPrivatTilstotende: BeregningsResultatAfpPrivat? = null
 
     /**
-     * AfpOffentligLivsvarigGrunnlag for tilstøtende
-     */
-    @Deprecated("Felt ikke i bruk. AfpOffentligLivsvarig er forventet satt på beregningsResultatAlderspensjonTilstotende")
-    var afpOffentligLivsvarigGrunnlagTilstotende: AfpOffentligLivsvarigGrunnlag? = null
-
-    /**
      * Beregningen ved virkningstidspunkt. Vil inneholde en AldersberegningKapittel19,
      * som igjen inneholder MinstePensjonsnivå, Basispensjon, Restpensjon, PensjonUnderUtbetaling
      * og BeregningsInformasjon.

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnForsorgingstilleggRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnForsorgingstilleggRequest.kt
@@ -100,7 +100,5 @@ class BeregnForsorgingstilleggRequest : ServiceRequest() {
     /**
      * Virkningstidspunkt for beregning av forsørgingstillegg.
      */
-    @Deprecated("Use virkLd instead")
-    var virk: Date? = null
     var virkLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnInstitusjonsoppholdRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnInstitusjonsoppholdRequest.kt
@@ -8,8 +8,6 @@ import java.util.*
 import java.time.LocalDate
 
 class BeregnInstitusjonsoppholdRequest : ServiceRequest() {
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     // bruker1 beregning1967

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnMinstepensjonRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnMinstepensjonRequest.kt
@@ -7,7 +7,5 @@ import java.time.LocalDate
  * Dataoverføringsobjekt, inndata, for tjenesten beregnMinstepensjon.
  */
 class BeregnMinstepensjonRequest : ServiceRequest() {
-    @Deprecated("Use virkLd instead")
-    var virk: Date? = null
     var virkLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnPensjonsBeholdningRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnPensjonsBeholdningRequest.kt
@@ -2,12 +2,9 @@ package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.grunnlag.Pensjonsbeholdning
 import no.nav.pensjon.regler.domain.grunnlag.Persongrunnlag
-import java.util.Date
 import java.time.LocalDate
 
 class BeregnPensjonsBeholdningRequest : ServiceRequest() {
-    @Deprecated("Use beholdningTomLd instead")
-    var beholdningTom: Date? = null
     var beholdningTomLd: LocalDate? = null
     var persongrunnlag: Persongrunnlag? = null
     var beholdning: Pensjonsbeholdning? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnPoengrekkeRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnPoengrekkeRequest.kt
@@ -4,10 +4,6 @@ import java.util.*
 import java.time.LocalDate
 
 class BeregnPoengrekkeRequest : ServiceRequest() {
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnUforetrygdRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnUforetrygdRequest.kt
@@ -11,11 +11,7 @@ import java.time.LocalDate
 class BeregnUforetrygdRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtaksliste = Vector<VilkarsVedtak>()
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
     var forrigeGjenlevendetillegg: Gjenlevendetillegg? = null
 

--- a/src/main/kotlin/no/nav/pensjon/regler/to/BeregnYtelseRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/BeregnYtelseRequest.kt
@@ -9,17 +9,11 @@ import java.time.LocalDate
 class BeregnYtelseRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
     var vilkarsvedtaksliste = Vector<VilkarsVedtak>()
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
     var ektefelleMottarPensjon = false
     var beregnForsorgingstillegg = false
     var beregnInstitusjonsopphold = false
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
-    @Deprecated("Use vedtakVirkFomLd instead")
-    var vedtakVirkFom: Date? = null
     var vedtakVirkFomLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/FaktorOmregnRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/FaktorOmregnRequest.kt
@@ -2,12 +2,9 @@ package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.beregning.Beregning
 import no.nav.pensjon.regler.domain.beregning2011.AbstraktBeregningsResultat
-import java.util.Date
 import java.time.LocalDate
 
 class FaktorOmregnRequest : ServiceRequest() {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var beregning1967: Beregning? = null
     var beregningsResultat2011: AbstraktBeregningsResultat? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/FaktoromregnBeregningBatchRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/FaktoromregnBeregningBatchRequest.kt
@@ -5,11 +5,7 @@ import java.util.*
 import java.time.LocalDate
 
 class FaktoromregnBeregningBatchRequest : ServiceRequest() {
-    @Deprecated("Use gammelGGjaldtDatoLd instead")
-    var gammelGGjaldtDato: Date? = null
     var gammelGGjaldtDatoLd: LocalDate? = null
-    @Deprecated("Use nyGOmregnFraDatoLd instead")
-    var nyGOmregnFraDato: Date? = null
     var nyGOmregnFraDatoLd: LocalDate? = null
     var beregningerTilFaktoromregningGrunnlagListe = Vector<BeregningerTilFaktoromregningGrunnlag>()
 

--- a/src/main/kotlin/no/nav/pensjon/regler/to/FaktoromregnInntektBatchRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/FaktoromregnInntektBatchRequest.kt
@@ -8,15 +8,11 @@ class FaktoromregnInntektBatchRequest : ServiceRequest() {
     /**
      * Dato for når gammel regulering gjaldt.
      */
-    @Deprecated("Use gammelReguleringGjaldtDatoLd instead")
-    var gammelReguleringGjaldtDato: Date? = null
     var gammelReguleringGjaldtDatoLd: LocalDate? = null
 
     /**
      * Ny dato det skal omregnes for.
      */
-    @Deprecated("Use nyReguleringOmregnFraDatoLd instead")
-    var nyReguleringOmregnFraDato: Date? = null
     var nyReguleringOmregnFraDatoLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/to/HentGrunnbelopListeRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/HentGrunnbelopListeRequest.kt
@@ -4,10 +4,6 @@ import java.util.*
 import java.time.LocalDate
 
 class HentGrunnbelopListeRequest : ServiceRequest() {
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/HentGyldigSatsRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/HentGyldigSatsRequest.kt
@@ -5,11 +5,7 @@ import java.util.*
 import java.time.LocalDate
 
 class HentGyldigSatsRequest : ServiceRequest() {
-    @Deprecated("Use fomDatoLd instead")
-    var fomDato: Date? = null
     var fomDatoLd: LocalDate? = null
-    @Deprecated("Use tomDatoLd instead")
-    var tomDato: Date? = null
     var tomDatoLd: LocalDate? = null
     var satsTypeEnum: SatsTypeEnum? = null
     var beregnetSomGift = false

--- a/src/main/kotlin/no/nav/pensjon/regler/to/IdentifiserRegelendringerRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/IdentifiserRegelendringerRequest.kt
@@ -30,14 +30,10 @@ class IdentifiserRegelendringerRequest : ServiceRequest() {
     /**
      * Fra og med dato for regelendringer.
      */
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
     /**
      * Til og med dato for regelendringer. Ved uviss tom-dato kan dagens dato benyttes.
      */
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/InntektsavkortningUforetrygdRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/InntektsavkortningUforetrygdRequest.kt
@@ -27,15 +27,11 @@ class InntektsavkortningUforetrygdRequest : ServiceRequest() {
     /**
      * Virkningstidspunkt for beregning av ny inntektsavkortning.
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     /**
      * Virkningstidspunkt for beregning av ny inntektsavkortning.
      */
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/to/KonverterAP1967TilAP2011Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/KonverterAP1967TilAP2011Request.kt
@@ -13,8 +13,6 @@ class KonverterAP1967TilAP2011Request : ServiceRequest() {
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
     var beregning: Beregning? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var epsMottarPensjon = false
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/KonverterTilUforetrygdRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/KonverterTilUforetrygdRequest.kt
@@ -12,8 +12,6 @@ class KonverterTilUforetrygdRequest : ServiceRequest() {
     var sisteUforepensjonBeregning: SisteUforepensjonBeregning? = null
     var sisteUforepensjonBeregningTilRevurdering: SisteUforepensjonBeregning? = null
     var vilkarsvedtaksliste = Vector<VilkarsVedtak>()
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     // Brukes til å si om en beregning skal faktorkonverteres eller ikke

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RegulerAfpPrivatBeregningRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RegulerAfpPrivatBeregningRequest.kt
@@ -5,11 +5,7 @@ import java.util.*
 import java.time.LocalDate
 
 class RegulerAfpPrivatBeregningRequest : ServiceRequest() {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
-    @Deprecated("Use virkFomAfpFrivatUttakLd instead")
-    var virkFomAfpFrivatUttak: Date? = null
     var virkFomAfpFrivatUttakLd: LocalDate? = null
     var beregningsResultat: BeregningsResultatAfpPrivat? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RegulerBeregning2011Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RegulerBeregning2011Request.kt
@@ -9,14 +9,10 @@ import java.util.*
 import java.time.LocalDate
 
 class RegulerBeregning2011Request : ServiceRequest() {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var beregningsResultat: AbstraktBeregningsResultat? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
     var uttaksgradListe: ArrayList<Uttaksgrad> = ArrayList()
-    @Deprecated("Use fodselsdatoLd instead")
-    var fodselsdato: Date? = null
     var fodselsdatoLd: LocalDate? = null
 
     @Deprecated("Felt ikke i bruk. AfpOffentligLivsvarig er forventet satt på beregningsResultat")

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RegulerBeregning2011Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RegulerBeregning2011Request.kt
@@ -14,9 +14,6 @@ class RegulerBeregning2011Request : ServiceRequest() {
     var uttaksgradListe: ArrayList<Uttaksgrad> = ArrayList()
     var fodselsdato: Date? = null
 
-    @Deprecated("Felt ikke i bruk. AfpOffentligLivsvarig er forventet satt på beregningsResultat")
-    var afpOffentligLivsvarigGrunnlag: AfpOffentligLivsvarigGrunnlag? = null
-
     /**
      * Representerer grunnlaget for normert pensjonsalder
      *

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RegulerBeregningRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RegulerBeregningRequest.kt
@@ -9,8 +9,6 @@ import java.time.LocalDate
 
 class RegulerBeregningRequest : ServiceRequest() {
     var beregning1967: Beregning? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var uttaksgradListe: ArrayList<Uttaksgrad> = ArrayList()
     var brukersVilkarsvedtakListe: ArrayList<VilkarsVedtak> = ArrayList()

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RegulerPensjonsbeholdningRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RegulerPensjonsbeholdningRequest.kt
@@ -5,8 +5,6 @@ import java.util.*
 import java.time.LocalDate
 
 class RegulerPensjonsbeholdningRequest : ServiceRequest() {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var beregningsgrunnlagForPensjonsbeholdning: ArrayList<PersonPensjonsbeholdning> = ArrayList()
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2011Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2011Request.kt
@@ -13,11 +13,7 @@ class RevurderingAlderspensjon2011Request : ServiceRequest() {
     var vilkarsvedtakListe: Vector<VilkarsVedtak> = Vector()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
     var epsMottarPensjon = false
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
     var forrigeAldersBeregning: SisteAldersberegning2011? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2016Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2016Request.kt
@@ -13,8 +13,6 @@ class RevurderingAlderspensjon2016Request : ServiceRequest() {
     var vilkarsvedtakListe: List<VilkarsVedtak> = Vector()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
     var epsMottarPensjon = false
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var forrigeAldersBeregning: SisteAldersberegning2016? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2025Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingAlderspensjon2025Request.kt
@@ -14,8 +14,6 @@ class RevurderingAlderspensjon2025Request : ServiceRequest() {
     var vilkarsvedtakListe: ArrayList<VilkarsVedtak> = ArrayList()
     var infoPavirkendeYtelse: InfoPavirkendeYtelse? = null
     var epsMottarPensjon = false
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var sisteAldersBeregning2011: SisteAldersberegning2011? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingYtelse1967Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/RevurderingYtelse1967Request.kt
@@ -8,8 +8,6 @@ import java.util.*
 import java.time.LocalDate
 
 class RevurderingYtelse1967Request : ServiceRequest() {
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var kravhode: Kravhode? = null
     var vilkarsvedtakListe: Vector<VilkarsVedtak> = Vector()

--- a/src/main/kotlin/no/nav/pensjon/regler/to/SimuleringRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/SimuleringRequest.kt
@@ -1,13 +1,10 @@
 package no.nav.pensjon.regler.to
 
 import no.nav.pensjon.regler.domain.simulering.Simulering
-import java.util.*
 import java.time.LocalDate
 
 class SimuleringRequest() : ServiceRequest() {
     var simulering: Simulering? = null
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
     var ektefelleMottarPensjon = false
     var beregnForsorgingstillegg = false
@@ -16,17 +13,18 @@ class SimuleringRequest() : ServiceRequest() {
     @Deprecated("Use fomLd-constructor instead")
     constructor(
         simulering: Simulering?,
-        fom: Date?,
+        // fom: Date?,
         ektefelleMottarPensjon: Boolean,
         beregnForsorgingstillegg: Boolean,
         beregnInstitusjonsopphold: Boolean
     ) : this() {
         this.simulering = simulering
-        this.fom = fom
+//        this.fom = fom
         this.ektefelleMottarPensjon = ektefelleMottarPensjon
         this.beregnForsorgingstillegg = beregnForsorgingstillegg
         this.beregnInstitusjonsopphold = beregnInstitusjonsopphold
     }
+
 
     constructor(
         simulering: Simulering?,
@@ -40,12 +38,6 @@ class SimuleringRequest() : ServiceRequest() {
         this.ektefelleMottarPensjon = ektefelleMottarPensjon
         this.beregnForsorgingstillegg = beregnForsorgingstillegg
         this.beregnInstitusjonsopphold = beregnInstitusjonsopphold
-    }
-
-    @Deprecated("Use fomLd-constructor instead")
-    constructor(simulering: Simulering?, fom: Date?) : this() {
-        this.simulering = simulering
-        this.fom = fom
     }
 
     constructor(simulering: Simulering?, fom: LocalDate?) : this() {

--- a/src/main/kotlin/no/nav/pensjon/regler/to/SimuleringRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/SimuleringRequest.kt
@@ -10,22 +10,6 @@ class SimuleringRequest() : ServiceRequest() {
     var beregnForsorgingstillegg = false
     var beregnInstitusjonsopphold = false
 
-    @Deprecated("Use fomLd-constructor instead")
-    constructor(
-        simulering: Simulering?,
-        // fom: Date?,
-        ektefelleMottarPensjon: Boolean,
-        beregnForsorgingstillegg: Boolean,
-        beregnInstitusjonsopphold: Boolean
-    ) : this() {
-        this.simulering = simulering
-//        this.fom = fom
-        this.ektefelleMottarPensjon = ektefelleMottarPensjon
-        this.beregnForsorgingstillegg = beregnForsorgingstillegg
-        this.beregnInstitusjonsopphold = beregnInstitusjonsopphold
-    }
-
-
     constructor(
         simulering: Simulering?,
         fom: LocalDate?,

--- a/src/main/kotlin/no/nav/pensjon/regler/to/TrygdetidRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/TrygdetidRequest.kt
@@ -15,22 +15,16 @@ class TrygdetidRequest : ServiceRequest() {
     /**
      * Virkningstidspunktets fom. for ønsket ytelse.
      */
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
 
     /**
      * Tom for trygdetiden som skal beregnes. Kun for AP2011, AP2016 og AP2025.
      */
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
 
     /**
      * Første virkningstidspunkt,denne må være satt dersom personen er SOKER i persongrunnlaget.
      */
-    @Deprecated("Use brukerForsteVirkLd instead")
-    var brukerForsteVirk: Date? = null
     var brukerForsteVirkLd: LocalDate? = null
 
     /**

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjon2011Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjon2011Request.kt
@@ -9,16 +9,10 @@ import java.util.*
 class VilkarsprovAlderpensjon2011Request : ServiceRequest() {
     var kravhode: Kravhode? = null
 
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
 
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
-    @Deprecated("Use afpVirkFomLd instead")
-    var afpVirkFom: Date? = null
     var afpVirkFomLd: LocalDate? = null
 
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjon2016Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjon2016Request.kt
@@ -8,12 +8,8 @@ import java.time.LocalDate
 
 class VilkarsprovAlderpensjon2016Request : ServiceRequest() {
     var kravhode: Kravhode? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
-    @Deprecated("Use afpVirkFomLd instead")
-    var afpVirkFom: Date? = null
     var afpVirkFomLd: LocalDate? = null
     var sisteBeregning: SisteAldersberegning2016? = null
     var utforVilkarsberegning = false

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjon2025Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjon2025Request.kt
@@ -9,12 +9,8 @@ import java.time.LocalDate
 
 class VilkarsprovAlderpensjon2025Request : ServiceRequest() {
     var kravhode: Kravhode? = null
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
-    @Deprecated("Use afpVirkFomLd instead")
-    var afpVirkFom: Date? = null
     var afpVirkFomLd: LocalDate? = null
     var sisteBeregning: SisteAldersberegning2011? = null
     var utforVilkarsberegning = false

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjonForsteUttakRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjonForsteUttakRequest.kt
@@ -6,8 +6,6 @@ import java.time.LocalDate
 
 class VilkarsprovAlderpensjonForsteUttakRequest : ServiceRequest() {
     var kravHode: Kravhode? = null
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
     var uttaksgrad = 0
     var ft = 0.0

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjonOvergangskullRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovAlderpensjonOvergangskullRequest.kt
@@ -8,12 +8,8 @@ import java.time.LocalDate
 
 class VilkarsprovAlderpensjonOvergangskullRequest : ServiceRequest() {
     var kravHode: Kravhode? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
     var afpPrivatLivsvarig: AfpPrivatLivsvarig? = null
-    @Deprecated("Use afpVirkFomLd instead")
-    var afpVirkFom: Date? = null
     var afpVirkFomLd: LocalDate? = null
     var sisteBeregning: SisteAldersberegning2011? = null
 

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovEktefelletillegg2011Request.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovEktefelletillegg2011Request.kt
@@ -6,11 +6,7 @@ import java.time.LocalDate
 
 class VilkarsprovEktefelletillegg2011Request : ServiceRequest() {
     var kravhode: Kravhode? = null
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
 
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovForsorgingstilleggRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovForsorgingstilleggRequest.kt
@@ -6,10 +6,6 @@ import java.time.LocalDate
 
 class VilkarsprovForsorgingstilleggRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
-    @Deprecated("Use virkFomLd instead")
-    var virkFom: Date? = null
     var virkFomLd: LocalDate? = null
-    @Deprecated("Use virkTomLd instead")
-    var virkTom: Date? = null
     var virkTomLd: LocalDate? = null
 }

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovHalvpensjonRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovHalvpensjonRequest.kt
@@ -8,11 +8,7 @@ import java.time.LocalDate
 
 class VilkarsprovHalvpensjonRequest : ServiceRequest() {
     var kravhode: Kravhode? = null
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
     var grunnlagsrolleEnum: GrunnlagsrolleEnum? = null
 

--- a/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovRequest.kt
+++ b/src/main/kotlin/no/nav/pensjon/regler/to/VilkarsprovRequest.kt
@@ -3,30 +3,17 @@ package no.nav.pensjon.regler.to
 import no.nav.pensjon.regler.domain.beregning2011.SisteBeregning
 import no.nav.pensjon.regler.domain.krav.Kravhode
 import no.nav.pensjon.regler.domain.vedtak.VilkarsVedtak
-import java.util.*
 import java.time.LocalDate
 
 class VilkarsprovRequest : ServiceRequest {
     var kravhode: Kravhode? = null
     var sisteBeregning: SisteBeregning? = null
-    @Deprecated("Use fomLd instead")
-    var fom: Date? = null
     var fomLd: LocalDate? = null
-    @Deprecated("Use tomLd instead")
-    var tom: Date? = null
     var tomLd: LocalDate? = null
     var vilkarsvedtakliste: List<VilkarsVedtak> = mutableListOf()
 
     constructor()
 
-    @Deprecated("Use fomLd/tomLd constructor instead")
-    constructor(kravhode: Kravhode?, sisteBeregning: SisteBeregning?, fom: Date?, tom: Date?) {
-        this.kravhode = kravhode
-        this.sisteBeregning = sisteBeregning
-        this.fom = fom
-        this.tom = tom
-        this.vilkarsvedtakliste = mutableListOf()
-    }
 
     constructor(kravhode: Kravhode?, sisteBeregning: SisteBeregning?, fom: LocalDate?, tom: LocalDate?) {
         this.kravhode = kravhode


### PR DESCRIPTION
Inneholder breaking changes.

Felt som er fjernet har vært deprekert over lengre tid, og skal fint kunne fjernes.

Breaking Changes:

- Fjerner alle Date-varianter. Støtter nå kun LocalDate variantene med Ld-suffix.
- Fjernet deprekerte afpOffentligLivsvarigGrunnlag på RegulerBeregning2011
- Fjernet deprekert infoPavirkendeYtelse på BeregnAlderspensjon2025ForsteUttakRequest
- Fjernet deprekert annenTjenesteOk fra Pakkseddel
- Fjernet deprekert Kravlinje på VilkarsVedtak
- Fjernert deprekerte felt ifm. normert pensjonsalder

Avhengigheter:
- Diverse oppdateringer til avhengigheter.
